### PR TITLE
Fixed an issue regarding showing a value instead of a label

### DIFF
--- a/src/aura/MultiSelect/MultiSelectHelper.js
+++ b/src/aura/MultiSelect/MultiSelectHelper.js
@@ -23,8 +23,8 @@
     });
 
     component.set("v.options_", options);
-    var values = this.getSelectedValues(component);
-    this.setInfoText(component, values);
+    var labels = this.getSelectedLabels(component);
+    this.setInfoText(component, labels);
   },  
 
   setInfoText: function(component, values) {


### PR DESCRIPTION
Fixed a following issue: in case if the "options" attribute contains an option selected at the moment of component initiation, a value is displayed instead of a label. The sample data is following:

```
<aura:attribute name="options" type="Object[]" default="[
{
    'label': 'Label',
    'value': 'Value',
    'selected' : true
}]"/>
```